### PR TITLE
WL-3765 Bind against the newer version of tomcat.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <sakai.spring.version>3.2.3.RELEASE</sakai.spring.version>
     <sakai.spring.test.artifactId>spring-test</sakai.spring.test.artifactId>
     <sakai.spring.test.version>3.2.3.RELEASE</sakai.spring.test.version>
-    <sakai.tomcat.version>7.0.42</sakai.tomcat.version>
+    <sakai.tomcat.version>7.0.56</sakai.tomcat.version>
     <sakai.velocity.version>1.6.4</sakai.velocity.version>
     <sakai.xerces.impl.version>2.6.2</sakai.xerces.impl.version>
     <sakai.xerces.api.version>2.6.2</sakai.xerces.api.version>


### PR DESCRIPTION
This is because we were compiling and running against different versions (results in runtime bugs).
